### PR TITLE
Do not try to move items to next memory tier in evictNormalItemForSlabRelease

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -2930,9 +2930,6 @@ CacheAllocator<CacheTrait>::evictNormalItemForSlabRelease(Item& item) {
     return ItemHandle{};
   }
 
-  auto evictHandle = tryEvictToNextMemoryTier(&item);
-  if(evictHandle) return evictHandle;
-
   auto predicate = [](const Item& it) { return it.getRefCount() == 0; };
 
   const bool evictToNvmCache = shouldWriteToNvmCache(item);


### PR DESCRIPTION
Moving was already tried in releaseSlabImpl (moveForSlabRelease call).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/27)
<!-- Reviewable:end -->
