### PR TITLE
Aadding new configs to hit_ratio/graph_cache_leader_fobj

### DIFF
--- a/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-4GB-DRAM-4GB-PMEM.json
+++ b/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-4GB-DRAM-4GB-PMEM.json
@@ -1,0 +1,42 @@
+{
+  "cache_config": {
+    "cacheSizeMB": 8192,
+    "usePosixShm": true,
+    "poolRebalanceIntervalSec": 0,
+    "persistedCacheDir": "/tmp/mem-tier",
+    "memoryTiers" : [
+      {
+        "ratio": 1
+      },
+      {
+        "ratio": 1,
+        "file": "/pmem/memory-mapped-tier"
+      }
+    ]
+  }, 
+  "test_config": 
+    {
+      "addChainedRatio": 0.0, 
+      "delRatio": 0.0, 
+      "enableLookaside": true, 
+      "getRatio": 0.7684563460126871, 
+      "keySizeRange": [
+        1, 
+        8, 
+        64
+      ], 
+      "keySizeRangeProbability": [
+        0.3, 
+        0.7
+      ], 
+      "loneGetRatio": 0.2315436539873129, 
+      "numKeys": 71605574, 
+      "numOps": 5000000, 
+      "numThreads": 24, 
+      "popDistFile": "pop.json", 
+       
+      "setRatio": 0.0, 
+      "valSizeDistFile": "sizes.json"
+    }
+ 
+}

--- a/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-8GB-DRAM.json
+++ b/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-8GB-DRAM.json
@@ -1,0 +1,33 @@
+{
+  "cache_config": {
+    "cacheSizeMB": 8192,
+    "usePosixShm": true,
+    "poolRebalanceIntervalSec": 0,
+    "persistedCacheDir": "/tmp/mem-tier"
+  }, 
+  "test_config": 
+    {
+      "addChainedRatio": 0.0, 
+      "delRatio": 0.0, 
+      "enableLookaside": true, 
+      "getRatio": 0.7684563460126871, 
+      "keySizeRange": [
+        1, 
+        8, 
+        64
+      ], 
+      "keySizeRangeProbability": [
+        0.3, 
+        0.7
+      ], 
+      "loneGetRatio": 0.2315436539873129, 
+      "numKeys": 71605574, 
+      "numOps": 5000000, 
+      "numThreads": 24, 
+      "popDistFile": "pop.json", 
+       
+      "setRatio": 0.0, 
+      "valSizeDistFile": "sizes.json"
+    }
+ 
+}

--- a/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-8GB-PMEM.json
+++ b/cachelib/cachebench/test_configs/hit_ratio/graph_cache_leader_fbobj/config-8GB-PMEM.json
@@ -1,0 +1,39 @@
+{
+  "cache_config": {
+    "cacheSizeMB": 8192,
+    "usePosixShm": true,
+    "poolRebalanceIntervalSec": 0,
+    "persistedCacheDir": "/tmp/mem-tier",
+    "memoryTiers" : [
+      {
+        "ratio": 1,
+        "file": "/pmem/memory-mapped-tier"
+      }
+    ]
+  }, 
+  "test_config": 
+    {
+      "addChainedRatio": 0.0, 
+      "delRatio": 0.0, 
+      "enableLookaside": true, 
+      "getRatio": 0.7684563460126871, 
+      "keySizeRange": [
+        1, 
+        8, 
+        64
+      ], 
+      "keySizeRangeProbability": [
+        0.3, 
+        0.7
+      ], 
+      "loneGetRatio": 0.2315436539873129, 
+      "numKeys": 71605574, 
+      "numOps": 5000000, 
+      "numThreads": 24, 
+      "popDistFile": "pop.json", 
+       
+      "setRatio": 0.0, 
+      "valSizeDistFile": "sizes.json"
+    }
+ 
+}


### PR DESCRIPTION
According to our conversation with the CacheLib team I have added cachebench configs for hit_ratio/graph_cache_leader_fobj adjusted for our setups

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/32)
<!-- Reviewable:end -->
