### PR TITLE
Do not compensate for rounding error when calculating tier sizes

### DIFF
--- a/cachelib/allocator/CacheAllocatorConfig.h
+++ b/cachelib/allocator/CacheAllocatorConfig.h
@@ -883,12 +883,6 @@ CacheAllocatorConfig<T>::getMemoryTierConfigs() const {
     sum_sizes += tier_config.getSize();
   }
 
-  if (size != sum_sizes) {
-    // Adjust capacity of the last tier to account for rounding error
-    config.back().setSize(
-      config.back().getSize() + (getCacheSize() - sum_sizes));
-  }
-
   return config;
 }
 


### PR DESCRIPTION
Compensation results in ratios being different than originially specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/43)
<!-- Reviewable:end -->
