### PR TITLE
Fix issue with "Destorying an unresolved handle"

### DIFF
--- a/cachelib/allocator/Handle.h
+++ b/cachelib/allocator/Handle.h
@@ -392,6 +392,12 @@ struct ReadHandleImpl {
       }
     }
 
+   protected:
+    friend class ReadHandleImpl;
+    // Method used only by ReadHandleImpl ctor
+    void discard() {
+      it_.store(nullptr, std::memory_order_relaxed);
+    }
    private:
     // we are waiting on Item* to be set to a value. One of the valid values is
     // nullptr. So choose something that we dont expect to indicate a ptr
@@ -475,6 +481,7 @@ struct ReadHandleImpl {
     if (it_ && it_->isIncomplete()) {
       waitContext_ = std::make_shared<ItemWaitContext>(alloc);
       if (!alloc_->addWaitContextForMovingItem(it->getKey(), waitContext_)) {
+        waitContext_->discard();
         waitContext_.reset();
       }
     }


### PR DESCRIPTION
The issue happened when ReadHandleImpl ctor needs to destroy
waitContext_ because addWaitContextForMovingItem() returns false.
So before destroying waitContext_ we are calling discard method to
notify ~ItemWaitContext() that Item is ready.