### PR TITLE
Fix tests compilation

### DIFF
--- a/cachelib/common/CMakeLists.txt
+++ b/cachelib/common/CMakeLists.txt
@@ -50,6 +50,9 @@ if (BUILD_TESTS)
   add_library (common_test_utils STATIC
     TestUtils.cpp
   )
+  target_link_libraries(common_test_utils PUBLIC
+    Folly::folly
+  )
   add_library (common_test_support OBJECT
     hothash/HotHashDetectorTest.cpp
     piecewise/GenericPiecesTest.cpp


### PR DESCRIPTION
Link folly to common_test_utils. It is required since common_test_utils
use folly/Random.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/62)
<!-- Reviewable:end -->
