### PR TITLE
Added required packages to install Intel ittapi

### DIFF
--- a/docker/images/centos-8streams.Dockerfile
+++ b/docker/images/centos-8streams.Dockerfile
@@ -7,7 +7,9 @@ git \
 tzdata \
 vim \
 gdb \
-clang
+clang \
+python36 \
+glibc-devel.i686
 
 COPY ./install-cachelib-deps.sh ./install-cachelib-deps.sh
 RUN ./install-cachelib-deps.sh


### PR DESCRIPTION
Added the two required packages needed to build intel ittapi if you decide to build with -I

Two packages are

python36
glibc-devel.i686

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/67)
<!-- Reviewable:end -->
