### PR TITLE
Extend cachbench with touch value

### DIFF
--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -64,9 +64,11 @@ class Cache {
   //                      cache.
   // @param cacheDir      optional directory for the cache to enable
   //                      persistence across restarts.
+  // @param touchValue    read entire value on find
   explicit Cache(const CacheConfig& config,
                  ChainedItemMovingSync movingSync = {},
-                 std::string cacheDir = "");
+                 std::string cacheDir = "",
+                 bool touchValue = false);
 
   ~Cache();
 
@@ -168,8 +170,8 @@ class Cache {
     return getSize(item.get());
   }
 
-  // checks if values stored in it matches expectedValue_.
-  void validateValue(const ItemHandle &it) const;
+  // read entire value on find.
+  void touchValue(const ItemHandle& it) const;
 
   // returns the size of the item, taking into account ItemRecords could be
   // enabled.
@@ -228,14 +230,11 @@ class Cache {
   // @param keys  list of keys that the stressor uses for the workload.
   void enableConsistencyCheck(const std::vector<std::string>& keys);
 
-  // enables validating all values on find. Each value is compared to
-  // expected Value.
-  void enableValueValidating(const std::string &expectedValue);
-
   // returns true if the consistency checking is enabled.
   bool consistencyCheckEnabled() const { return valueTracker_ != nullptr; }
 
-  bool valueValidatingEnabled() const { return expectedValue_.has_value(); }
+  // returns true if touching value is enabled.
+  bool touchValueEnabled() const { return touchValue_; }
 
   // return true if the key was previously detected to be inconsistent. This
   // is useful only when consistency checking is enabled by calling
@@ -359,8 +358,8 @@ class Cache {
   // tracker for consistency monitoring.
   std::unique_ptr<ValueTracker> valueTracker_;
 
-  // exceptected value of all items in Cache.
-  std::optional<std::string> expectedValue_;
+  // read entire value on find.
+  bool touchValue_{false};
 
   // reading of the nand bytes written for the benchmark if enabled.
   const uint64_t nandBytesBegin_{0};

--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -68,7 +68,7 @@ class Cache {
   explicit Cache(const CacheConfig& config,
                  ChainedItemMovingSync movingSync = {},
                  std::string cacheDir = "",
-                 bool touchValue = false);
+                 bool touchValue = true);
 
   ~Cache();
 
@@ -359,7 +359,7 @@ class Cache {
   std::unique_ptr<ValueTracker> valueTracker_;
 
   // read entire value on find.
-  bool touchValue_{false};
+  bool touchValue_{true};
 
   // reading of the nand bytes written for the benchmark if enabled.
   const uint64_t nandBytesBegin_{0};

--- a/cachelib/cachebench/runner/CacheStressor.h
+++ b/cachelib/cachebench/runner/CacheStressor.h
@@ -93,7 +93,8 @@ class CacheStressor : public Stressor {
       cacheConfig.ticker = ticker_;
     }
 
-    cache_ = std::make_unique<CacheT>(cacheConfig, movingSync);
+    cache_ = std::make_unique<CacheT>(cacheConfig, movingSync, "",
+                                      config_.touchValue);
     if (config_.opPoolDistribution.size() > cache_->numPools()) {
       throw std::invalid_argument(folly::sformat(
           "more pools specified in the test than in the cache. "
@@ -109,9 +110,6 @@ class CacheStressor : public Stressor {
 
     if (config_.checkConsistency) {
       cache_->enableConsistencyCheck(wg_->getAllKeys());
-    }
-    if (config_.validateValue) {
-      cache_->enableValueValidating(hardcodedString_);
     }
     if (config_.opRatePerSec > 0) {
       rateLimiter_ = std::make_unique<folly::BasicTokenBucket<>>(

--- a/cachelib/cachebench/util/Config.cpp
+++ b/cachelib/cachebench/util/Config.cpp
@@ -34,7 +34,7 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, samplingIntervalMs);
 
   JSONSetVal(configJson, checkConsistency);
-  JSONSetVal(configJson, validateValue);
+  JSONSetVal(configJson, touchValue);
 
   JSONSetVal(configJson, numOps);
   JSONSetVal(configJson, numThreads);

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -197,7 +197,7 @@ struct StressorConfig : public JSONConfig {
 
   // If enabled, each value will be read on find. This is useful for measuring
   // performance of value access.
-  bool touchValue{false};
+  bool touchValue{true};
 
   uint64_t numOps{0};     // operation per thread
   uint64_t numThreads{0}; // number of threads that will run

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -195,6 +195,10 @@ struct StressorConfig : public JSONConfig {
   // Mutually exclusive with checkConsistency
   bool validateValue{false};
 
+  // If enabled, each value will be read on find. This is useful for measuring
+  // performance of value access.
+  bool touchValue{false};
+
   uint64_t numOps{0};     // operation per thread
   uint64_t numThreads{0}; // number of threads that will run
   uint64_t numKeys{0};    // number of keys that will be used


### PR DESCRIPTION
The main purpose of this patch is to better simulate workloads in
cachebench. Setting touchValue to true allows to see performance
impact of using different mediums for memory cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/85)
<!-- Reviewable:end -->
