### PR TITLE
Add memory usage statistics for slabs and allocation classes

### DIFF
--- a/cachelib/allocator/Cache.h
+++ b/cachelib/allocator/Cache.h
@@ -100,6 +100,9 @@ class CacheBase {
   // @param poolId   the pool id
   virtual PoolStats getPoolStats(PoolId poolId) const = 0;
 
+  virtual AllocationClassBaseStat getAllocationClassStats(TierId, PoolId pid, ClassId cid)
+      const = 0;
+
   // @param poolId   the pool id
   virtual AllSlabReleaseEvents getAllSlabReleaseEvents(PoolId poolId) const = 0;
 

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1064,6 +1064,10 @@ class CacheAllocator : public CacheBase {
   // return cache's memory usage stats.
   CacheMemoryStats getCacheMemoryStats() const override final;
 
+  // return basic stats for Allocation Class
+  AllocationClassBaseStat getAllocationClassStats(TierId tid, PoolId pid, ClassId cid)
+      const override final;
+
   // return the nvm cache stats map
   std::unordered_map<std::string, double> getNvmCacheStatsMap()
       const override final;
@@ -1208,6 +1212,8 @@ class CacheAllocator : public CacheBase {
 #pragma GCC diagnostic pop
 
  private:
+  double slabsApproxFreePercentage(TierId tid) const;
+
   // wrapper around Item's refcount and active handle tracking
   FOLLY_ALWAYS_INLINE void incRef(Item& it);
   FOLLY_ALWAYS_INLINE RefcountWithFlags::Value decRef(Item& it);

--- a/cachelib/allocator/CacheStats.h
+++ b/cachelib/allocator/CacheStats.h
@@ -98,6 +98,17 @@ struct MMContainerStat {
   uint64_t numTailAccesses;
 };
 
+struct AllocationClassBaseStat {
+  // size of allocation class
+  size_t allocSize{0};
+
+  // size of memory assigned to this allocation class
+  size_t memorySize{0};
+
+  // percent of free memory in this class
+  double approxFreePercent{0.0};
+};
+
 // cache related stats for a given allocation class.
 struct CacheStat {
   // allocation size for this container.
@@ -521,6 +532,9 @@ struct CacheMemoryStats {
 
   // rss size of the process
   size_t memRssSize{0};
+
+  // percentage of free slabs
+  std::vector<double> slabsApproxFreePercentages{0.0};
 };
 
 // Stats for compact cache

--- a/cachelib/allocator/memory/AllocationClass.cpp
+++ b/cachelib/allocator/memory/AllocationClass.cpp
@@ -51,6 +51,7 @@ AllocationClass::AllocationClass(ClassId classId,
       allocationSize_(allocSize),
       slabAlloc_(s),
       freedAllocations_{slabAlloc_.createSingleTierPtrCompressor<FreeAlloc>()} {
+  curAllocatedSlabs_ = allocatedSlabs_.size();
   checkState();
 }
 
@@ -87,6 +88,12 @@ void AllocationClass::checkState() const {
         "Current allocation slab {} is not in allocated slabs list",
         currSlab_));
   }
+
+  if (curAllocatedSlabs_ != allocatedSlabs_.size()) {
+    throw std::invalid_argument(folly::sformat(
+      "Mismatch in allocated slabs numbers"
+    ));
+  }
 }
 
 // TODO(stuclar): Add poolId to the metadata to be serialized when cache shuts
@@ -116,10 +123,12 @@ AllocationClass::AllocationClass(
     freeSlabs_.push_back(slabAlloc_.getSlabForIdx(freeSlabIdx));
   }
 
+  curAllocatedSlabs_ = allocatedSlabs_.size();
   checkState();
 }
 
 void AllocationClass::addSlabLocked(Slab* slab) {
+  curAllocatedSlabs_.fetch_add(1, std::memory_order_relaxed);
   canAllocate_ = true;
   auto header = slabAlloc_.getSlabHeader(slab);
   header->classId = classId_;
@@ -168,6 +177,7 @@ void* AllocationClass::allocateLocked() {
   }
 
   XDCHECK(canAllocate_);
+  curAllocatedSize_.fetch_add(getAllocSize(), std::memory_order_relaxed);
 
   // grab from the free list if possible.
   if (!freedAllocations_.empty()) {
@@ -270,6 +280,7 @@ SlabReleaseContext AllocationClass::startSlabRelease(
                          slab, getId()));
     }
     *allocIt = allocatedSlabs_.back();
+    curAllocatedSlabs_.fetch_sub(1, std::memory_order_relaxed);
     allocatedSlabs_.pop_back();
 
     // if slab is being carved currently, then update slabReleaseAllocMap
@@ -510,6 +521,7 @@ void AllocationClass::abortSlabRelease(const SlabReleaseContext& context) {
     }
     slabReleaseAllocMap_.erase(slabPtrVal);
     allocatedSlabs_.push_back(const_cast<Slab*>(slab));
+    curAllocatedSlabs_.fetch_add(1, std::memory_order_relaxed);
     // restore the classId and allocSize
     header->classId = classId_;
     header->allocSize = allocationSize_;
@@ -660,6 +672,8 @@ void AllocationClass::free(void* memory) {
     freedAllocations_.insert(*reinterpret_cast<FreeAlloc*>(memory));
     canAllocate_ = true;
   });
+
+  curAllocatedSize_.fetch_sub(getAllocSize(), std::memory_order_relaxed);
 }
 
 serialization::AllocationClassObject AllocationClass::saveState() const {
@@ -721,4 +735,13 @@ std::vector<bool>& AllocationClass::getSlabReleaseAllocMapLocked(
     const Slab* slab) {
   const auto slabPtrVal = getSlabPtrValue(slab);
   return slabReleaseAllocMap_.at(slabPtrVal);
+}
+
+double AllocationClass::approxFreePercentage() const {
+  if (getNumSlabs() == 0) {
+    return 100.0;
+  }
+
+  return 100.0 - 100.0 * static_cast<double>(curAllocatedSize_.load(std::memory_order_relaxed)) /
+    static_cast<double>(getNumSlabs() * Slab::kSize);
 }

--- a/cachelib/allocator/memory/MemoryAllocator.h
+++ b/cachelib/allocator/memory/MemoryAllocator.h
@@ -416,6 +416,14 @@ class MemoryAllocator {
     return memoryPoolManager_.getPoolIds();
   }
 
+  double approxFreeSlabsPercentage() const {
+    if (slabAllocator_.getNumUsableAndAdvisedSlabs() == 0)
+      return 100.0;
+  
+    return 100.0 - 100.0 * static_cast<double>(slabAllocator_.approxNumSlabsAllocated()) /
+     slabAllocator_.getNumUsableAndAdvisedSlabs();
+  }
+
   // fetches the memory pool for the id if one exists. This is purely to get
   // information out of the pool.
   //

--- a/cachelib/allocator/memory/SlabAllocator.cpp
+++ b/cachelib/allocator/memory/SlabAllocator.cpp
@@ -359,6 +359,8 @@ Slab* SlabAllocator::makeNewSlab(PoolId id) {
     return nullptr;
   }
 
+  numSlabsAllocated_.fetch_add(1, std::memory_order_relaxed);
+
   memoryPoolSize_[id] += sizeof(Slab);
   // initialize the header for the slab.
   initializeHeader(slab, id);
@@ -374,6 +376,8 @@ void SlabAllocator::freeSlab(Slab* slab) {
   }
 
   memoryPoolSize_[header->poolId] -= sizeof(Slab);
+  numSlabsAllocated_.fetch_sub(1, std::memory_order_relaxed);
+
   // grab the lock
   LockHolder l(lock_);
   freeSlabs_.push_back(slab);

--- a/cachelib/allocator/memory/SlabAllocator.h
+++ b/cachelib/allocator/memory/SlabAllocator.h
@@ -323,7 +323,13 @@ class SlabAllocator {
                                    memorySize_);
   }
 
- private:
+  size_t approxNumSlabsAllocated() const {
+    return numSlabsAllocated_.load(std::memory_order_relaxed);
+  }
+
+private:
+  std::atomic<size_t> numSlabsAllocated_{0};
+
   // null Slab* presenttation. With 4M Slab size, a valid slab index would never
   // reach 2^16 - 1;
   static constexpr SlabIdx kNullSlabIdx = std::numeric_limits<SlabIdx>::max();

--- a/cachelib/allocator/tests/CacheBaseTest.cpp
+++ b/cachelib/allocator/tests/CacheBaseTest.cpp
@@ -33,6 +33,11 @@ class CacheBaseTest : public CacheBase, public SlabAllocatorTestBase {
   const std::string getCacheName() const override { return cacheName; }
   const MemoryPool& getPool(PoolId) const override { return memoryPool_; }
   PoolStats getPoolStats(PoolId) const override { return PoolStats(); }
+  AllocationClassBaseStat getAllocationClassStats(TierId tid,
+                                                  PoolId,
+                                                  ClassId) const {
+    return AllocationClassBaseStat();
+  };
   AllSlabReleaseEvents getAllSlabReleaseEvents(PoolId) const override {
     return AllSlabReleaseEvents{};
   }

--- a/cachelib/cachebench/cache/Cache.cpp
+++ b/cachelib/cachebench/cache/Cache.cpp
@@ -22,6 +22,10 @@ DEFINE_bool(report_api_latency,
             false,
             "Enable reporting cache API latency tracking");
 
+DEFINE_bool(report_memory_usage_stats,
+            false,
+            "Enable reporting statistics for each allocation class");
+
 namespace facebook {
 namespace cachelib {
 namespace cachebench {} // namespace cachebench

--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -33,6 +33,7 @@
 #include "cachelib/cachebench/util/CacheConfig.h"
 
 DECLARE_bool(report_api_latency);
+DECLARE_bool(report_memory_usage_stats);
 
 namespace facebook {
 namespace cachelib {
@@ -248,6 +249,10 @@ class Cache {
 
   // return the stats for the pool.
   PoolStats getPoolStats(PoolId pid) const { return cache_->getPoolStats(pid); }
+
+  AllocationClassBaseStat getAllocationClassStats(TierId tid, PoolId pid, ClassId cid) const {
+    return cache_->getAllocationClassStats(tid, pid, cid);
+  }
 
   // return the total number of inconsistent operations detected since start.
   unsigned int getInconsistencyCount() const {


### PR DESCRIPTION
Printing those stats can be enabled by passing `-report_memory_usage_stats` to cachebench

Sample output:
```
tid 0 free slabs : 0.00%
tid 1 free slabs : 0.00%
tid 0 pid 0 cid   0    64.00B memorySize:     0.00B
tid 0 pid 0 cid   1    96.00B memorySize:    36.00MB
tid 0 pid 0 cid   2   144.00B memorySize:   124.00MB
tid 0 pid 0 cid   3   216.00B memorySize:   276.00MB
tid 0 pid 0 cid   4   328.00B memorySize:   744.00MB
tid 0 pid 0 cid   5   496.00B memorySize:   992.00MB
tid 0 pid 0 cid   6   744.00B memorySize:   508.00MB
tid 0 pid 0 cid   7     1.09KB memorySize:   416.00MB
tid 0 pid 0 cid   8     1.64KB memorySize:   212.00MB
tid 0 pid 0 cid   9     2.46KB memorySize:   132.00MB
tid 0 pid 0 cid  10     3.70KB memorySize:   152.00MB
tid 0 pid 0 cid  11     5.55KB memorySize:   136.00MB
tid 0 pid 0 cid  12     8.32KB memorySize:    36.00MB
tid 0 pid 0 cid  13    12.48KB memorySize:    20.00MB
tid 0 pid 0 cid  14    18.78KB memorySize:    20.00MB
tid 0 pid 0 cid  15    28.24KB memorySize:    32.00MB
tid 0 pid 0 cid  16    42.66KB memorySize:   200.00MB
tid 0 pid 0 cid  17    64.00KB memorySize:    36.00MB
tid 0 pid 0 cid  18    97.52KB memorySize:    12.00MB
tid 0 pid 0 cid  19   151.70KB memorySize:     4.00MB
tid 0 pid 0 cid  20   227.55KB memorySize:     4.00MB
tid 0 pid 0 cid  21   372.36KB memorySize:     0.00B
tid 0 pid 0 cid  22   585.14KB memorySize:     0.00B
tid 0 pid 0 cid  23     1.00MB memorySize:     0.00B
tid 1 pid 0 cid   0    64.00B memorySize:     0.00B
tid 1 pid 0 cid   1    96.00B memorySize:    40.00MB
tid 1 pid 0 cid   2   144.00B memorySize:   124.00MB
tid 1 pid 0 cid   3   216.00B memorySize:   272.00MB
tid 1 pid 0 cid   4   328.00B memorySize:   760.00MB
tid 1 pid 0 cid   5   496.00B memorySize:   984.00MB
tid 1 pid 0 cid   6   744.00B memorySize:   508.00MB
tid 1 pid 0 cid   7     1.09KB memorySize:   424.00MB
tid 1 pid 0 cid   8     1.64KB memorySize:   208.00MB
tid 1 pid 0 cid   9     2.46KB memorySize:   136.00MB
tid 1 pid 0 cid  10     3.70KB memorySize:   148.00MB
tid 1 pid 0 cid  11     5.55KB memorySize:   132.00MB
tid 1 pid 0 cid  12     8.32KB memorySize:    32.00MB
tid 1 pid 0 cid  13    12.48KB memorySize:    16.00MB
tid 1 pid 0 cid  14    18.78KB memorySize:    20.00MB
tid 1 pid 0 cid  15    28.24KB memorySize:    32.00MB
tid 1 pid 0 cid  16    42.66KB memorySize:   208.00MB
tid 1 pid 0 cid  17    64.00KB memorySize:    32.00MB
tid 1 pid 0 cid  18    97.52KB memorySize:    12.00MB
tid 1 pid 0 cid  19   151.70KB memorySize:     4.00MB
tid 1 pid 0 cid  20   227.55KB memorySize:     0.00B
tid 1 pid 0 cid  21   372.36KB memorySize:     0.00B
tid 1 pid 0 cid  22   585.14KB memorySize:     0.00B
tid 1 pid 0 cid  23     1.00MB memorySize:     0.00B
tid 0 pid 0 cid   0    64.00B free: 100.00%
tid 0 pid 0 cid   1    96.00B free: 0.00%
tid 0 pid 0 cid   2   144.00B free: 0.00%
tid 0 pid 0 cid   3   216.00B free: 0.00%
tid 0 pid 0 cid   4   328.00B free: 0.00%
tid 0 pid 0 cid   5   496.00B free: 0.00%
tid 0 pid 0 cid   6   744.00B free: 0.01%
tid 0 pid 0 cid   7     1.09KB free: 0.02%
tid 0 pid 0 cid   8     1.64KB free: 0.02%
tid 0 pid 0 cid   9     2.46KB free: 0.02%
tid 0 pid 0 cid  10     3.70KB free: 0.04%
tid 0 pid 0 cid  11     5.55KB free: 0.06%
tid 0 pid 0 cid  12     8.32KB free: 0.06%
tid 0 pid 0 cid  13    12.48KB free: 0.03%
tid 0 pid 0 cid  14    18.78KB free: 0.04%
tid 0 pid 0 cid  15    28.24KB free: 0.02%
tid 0 pid 0 cid  16    42.66KB free: 0.01%
tid 0 pid 0 cid  17    64.00KB free: 0.00%
tid 0 pid 0 cid  18    97.52KB free: 0.00%
tid 0 pid 0 cid  19   151.70KB free: 0.00%
tid 0 pid 0 cid  20   227.55KB free: 61.11%
tid 0 pid 0 cid  21   372.36KB free: 100.00%
tid 0 pid 0 cid  22   585.14KB free: 100.00%
tid 0 pid 0 cid  23     1.00MB free: 100.00%
tid 1 pid 0 cid   0    64.00B free: 100.00%
tid 1 pid 0 cid   1    96.00B free: 0.00%
tid 1 pid 0 cid   2   144.00B free: 0.00%
tid 1 pid 0 cid   3   216.00B free: 0.00%
tid 1 pid 0 cid   4   328.00B free: 0.00%
tid 1 pid 0 cid   5   496.00B free: 0.00%
tid 1 pid 0 cid   6   744.00B free: 0.01%
tid 1 pid 0 cid   7     1.09KB free: 0.02%
tid 1 pid 0 cid   8     1.64KB free: 0.02%
tid 1 pid 0 cid   9     2.46KB free: 0.02%
tid 1 pid 0 cid  10     3.70KB free: 0.04%
tid 1 pid 0 cid  11     5.55KB free: 0.06%
tid 1 pid 0 cid  12     8.32KB free: 0.06%
tid 1 pid 0 cid  13    12.48KB free: 0.03%
tid 1 pid 0 cid  14    18.78KB free: 0.04%
tid 1 pid 0 cid  15    28.24KB free: 0.02%
tid 1 pid 0 cid  16    42.66KB free: 0.01%
tid 1 pid 0 cid  17    64.00KB free: 0.00%
tid 1 pid 0 cid  18    97.52KB free: 0.00%
tid 1 pid 0 cid  19   151.70KB free: 0.00%
tid 1 pid 0 cid  20   227.55KB free: 100.00%
tid 1 pid 0 cid  21   372.36KB free: 100.00%
tid 1 pid 0 cid  22   585.14KB free: 100.00%
tid 1 pid 0 cid  23     1.00MB free: 100.00%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/91)
<!-- Reviewable:end -->
