### PR TITLE
remove from mmcontainer while iterator is held

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -2956,6 +2956,7 @@ CacheAllocator<CacheTrait>::evictNormalItem(Item& item,
 
   if (skipIfTokenInvalid && evictToNvmCache && !token.isValid()) {
     stats_.evictFailConcurrentFill.inc();
+    //if we have failed and the item is not in mmContainer what should we do??
     return ItemHandle{};
   }
 
@@ -2965,6 +2966,11 @@ CacheAllocator<CacheTrait>::evictNormalItem(Item& item,
   auto handle = accessContainer_->removeIf(item, std::move(predicate));
 
   if (!handle) {
+    //if we have failed and the item is not in mmContainer what should we do??
+    if (!inMMContainer) {
+        insertInMMContainer(item);
+        stats_.evictFailNotInMMContainer.inc();
+    }
     return handle;
   }
 

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1404,7 +1404,7 @@ class CacheAllocator : public CacheBase {
   //
   // @return true  If the move was completed, and the containers were updated
   //               successfully.
-  ItemHandle moveRegularItemOnEviction(Item& oldItem, ItemHandle& newItemHdl);
+  ItemHandle moveRegularItemOnEviction(Item& oldItem, ItemHandle& newItemHdl, bool inMMContainer);
 
   // Moves a regular item to a different slab. This should only be used during
   // slab release after the item's moving bit has been set. The user supplied
@@ -1571,7 +1571,7 @@ class CacheAllocator : public CacheBase {
   //
   // @return valid handle to the item. This will be the last
   //         handle to the item. On failure an empty handle.
-  WriteHandle tryEvictToNextMemoryTier(TierId tid, PoolId pid, Item& item);
+  WriteHandle tryEvictToNextMemoryTier(TierId tid, PoolId pid, Item& item, bool inMMContainer);
 
   // Try to move the item down to the next memory tier
   //
@@ -1579,7 +1579,7 @@ class CacheAllocator : public CacheBase {
   //
   // @return valid handle to the item. This will be the last
   //         handle to the item. On failure an empty handle. 
-  WriteHandle tryEvictToNextMemoryTier(Item& item);
+  WriteHandle tryEvictToNextMemoryTier(Item& item, bool inMMContainer);
 
   size_t memoryTierSize(TierId tid) const;
 
@@ -1708,7 +1708,7 @@ class CacheAllocator : public CacheBase {
   //
   // @return last handle for corresponding to item on success. empty handle on
   // failure. caller can retry if needed.
-  ItemHandle evictNormalItem(Item& item, bool skipIfTokenInvalid = false);
+  ItemHandle evictNormalItem(Item& item, bool skipIfTokenInvalid = false, bool inMMContainer = true);
 
   // Helper function to evict a child item for slab release
   // As a side effect, the parent item is also evicted

--- a/cachelib/allocator/CacheStats.cpp
+++ b/cachelib/allocator/CacheStats.cpp
@@ -127,6 +127,7 @@ void Stats::populateGlobalCacheStats(GlobalCacheStats& ret) const {
   ret.invalidAllocs = invalidAllocs.get();
   ret.numRefcountOverflow = numRefcountOverflow.get();
 
+  ret.numEvictionFailureFromNotInMMContainer = evictFailNotInMMContainer.get();
   ret.numEvictionFailureFromAccessContainer = evictFailAC.get();
   ret.numEvictionFailureFromConcurrentFill = evictFailConcurrentFill.get();
   ret.numEvictionFailureFromParentAccessContainer = evictFailParentAC.get();

--- a/cachelib/allocator/CacheStats.h
+++ b/cachelib/allocator/CacheStats.h
@@ -437,6 +437,7 @@ struct GlobalCacheStats {
   uint64_t numChainedParentItems{0};
 
   // number of eviction failures
+  uint64_t numEvictionFailureFromNotInMMContainer{0};
   uint64_t numEvictionFailureFromAccessContainer{0};
   uint64_t numEvictionFailureFromConcurrentFill{0};
   uint64_t numEvictionFailureFromParentAccessContainer{0};

--- a/cachelib/allocator/CacheStatsInternal.h
+++ b/cachelib/allocator/CacheStatsInternal.h
@@ -223,6 +223,9 @@ struct Stats {
 
   // Eviction failures due to parent cannot be removed from access container
   AtomicCounter evictFailParentAC{0};
+  
+  // Eviction failures due to not being in mmContainer and not removed from access container
+  AtomicCounter evictFailNotInMMContainer{0};
 
   // Eviction failures due to parent cannot be removed because it's being
   // moved

--- a/cachelib/allocator/MM2Q-inl.h
+++ b/cachelib/allocator/MM2Q-inl.h
@@ -304,15 +304,15 @@ bool MM2Q::Container<T, HookPtr>::remove(T& node) noexcept {
 }
 
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
-void MM2Q::Container<T, HookPtr>::remove(Iterator& it) noexcept {
+bool MM2Q::Container<T, HookPtr>::remove(Iterator& it) noexcept {
   T& node = *it;
   XDCHECK(node.isInMMContainer());
-  ++it;
   // rebalance should not be triggered inside this remove, because changing the
   // queues while having the EvictionIterator can cause inconsistency problem
   // for the iterator. Also, this remove is followed by an insertion into the
   // same container, which will trigger rebalance.
   removeLocked(node, /* doRebalance = */ false);
+  return true;
 }
 
 template <typename T, MM2Q::Hook<T> T::*HookPtr>

--- a/cachelib/allocator/MM2Q.h
+++ b/cachelib/allocator/MM2Q.h
@@ -411,7 +411,7 @@ class MM2Q {
     //          state of node is unchanged.
     bool remove(T& node) noexcept;
 
-    // same as the above but uses an iterator context. The iterator is updated
+    // same as the above but uses an iterator context. The iterator is NOT updated
     // on removal of the corresponding node to point to the next node. The
     // iterator context holds the lock on the lru.
     //
@@ -421,7 +421,7 @@ class MM2Q {
     // having the iterator can cause probelms.
     //
     // @param it    Iterator that will be removed
-    void remove(Iterator& it) noexcept;
+    bool remove(Iterator& it) noexcept;
 
     // replaces one node with another, at the same position
     //

--- a/cachelib/allocator/MMLru-inl.h
+++ b/cachelib/allocator/MMLru-inl.h
@@ -275,11 +275,11 @@ bool MMLru::Container<T, HookPtr>::remove(T& node) noexcept {
 }
 
 template <typename T, MMLru::Hook<T> T::*HookPtr>
-void MMLru::Container<T, HookPtr>::remove(Iterator& it) noexcept {
+bool MMLru::Container<T, HookPtr>::remove(Iterator& it) noexcept {
   T& node = *it;
   XDCHECK(node.isInMMContainer());
-  ++it;
   removeLocked(node);
+  return true;
 }
 
 template <typename T, MMLru::Hook<T> T::*HookPtr>

--- a/cachelib/allocator/MMLru.h
+++ b/cachelib/allocator/MMLru.h
@@ -309,14 +309,14 @@ class MMLru {
     bool remove(T& node) noexcept;
 
     using Iterator = Iterator;
-    // same as the above but uses an iterator context. The iterator is updated
+    // same as the above but uses an iterator context. The iterator is NOT updated
     // on removal of the corresponding node to point to the next node. The
     // iterator context holds the lock on the lru.
     //
     // iterator will be advanced to the next node after removing the node
     //
     // @param it    Iterator that will be removed
-    void remove(Iterator& it) noexcept;
+    bool remove(Iterator& it) noexcept;
 
     // replaces one node with another, at the same position
     //

--- a/cachelib/allocator/MMTinyLFU-inl.h
+++ b/cachelib/allocator/MMTinyLFU-inl.h
@@ -254,11 +254,11 @@ bool MMTinyLFU::Container<T, HookPtr>::remove(T& node) noexcept {
 }
 
 template <typename T, MMTinyLFU::Hook<T> T::*HookPtr>
-void MMTinyLFU::Container<T, HookPtr>::remove(Iterator& it) noexcept {
+bool MMTinyLFU::Container<T, HookPtr>::remove(Iterator& it) noexcept {
   T& node = *it;
   XDCHECK(node.isInMMContainer());
-  ++it;
   removeLocked(node);
+  return true;
 }
 
 template <typename T, MMTinyLFU::Hook<T> T::*HookPtr>

--- a/cachelib/allocator/MMTinyLFU.h
+++ b/cachelib/allocator/MMTinyLFU.h
@@ -337,14 +337,14 @@ class MMTinyLFU {
     bool remove(T& node) noexcept;
 
     class Iterator;
-    // same as the above but uses an iterator context. The iterator is updated
+    // same as the above but uses an iterator context. The iterator is NOT updated
     // on removal of the corresponding node to point to the next node. The
     // iterator context holds the lock on the lru.
     //
     // iterator will be advanced to the next node after removing the node
     //
     // @param it    Iterator that will be removed
-    void remove(Iterator& it) noexcept;
+    bool remove(Iterator& it) noexcept;
 
     // replaces one node with another, at the same position
     //

--- a/cachelib/cachebench/cache/Cache-inl.h
+++ b/cachelib/cachebench/cache/Cache-inl.h
@@ -504,6 +504,8 @@ Stats Cache<Allocator>::getStats() const {
 
   Stats ret;
   ret.numEvictions = aggregate.numEvictions();
+  ret.numEvictFailAC = cacheStats.numEvictionFailureFromAccessContainer;
+  ret.numEvictFailNotInMMContainer = cacheStats.numEvictionFailureFromNotInMMContainer;
   ret.numItems = aggregate.numItems();
   ret.allocAttempts = cacheStats.allocAttempts;
   ret.allocFailures = cacheStats.allocFailures;

--- a/cachelib/cachebench/cache/CacheStats.h
+++ b/cachelib/cachebench/cache/CacheStats.h
@@ -27,6 +27,8 @@ namespace cachelib {
 namespace cachebench {
 struct Stats {
   uint64_t numEvictions{0};
+  uint64_t numEvictFailAC{0};
+  uint64_t numEvictFailNotInMMContainer{0};
   uint64_t numItems{0};
 
   uint64_t allocAttempts{0};
@@ -113,7 +115,11 @@ struct Stats {
                           allocAttempts,
                           invertPctFn(allocFailures, allocAttempts))
         << std::endl;
+
+
     out << folly::sformat("RAM Evictions : {:,}", numEvictions) << std::endl;
+    out << folly::sformat("RAM Evictions Failures : {:,}", numEvictFailAC) << std::endl;
+    out << folly::sformat("RAM Evictions FailNotInMMContainer : {:,}", numEvictFailNotInMMContainer) << std::endl;
 
     if (numCacheGets > 0) {
       out << folly::sformat("Cache Gets    : {:,}", numCacheGets) << std::endl;


### PR DESCRIPTION
I see about 33% improvement in GET and SET throughput and 50% reduction in p99 latency if we remove the candidate from the mmContainer first. 

I'm opening this PR to find the correct approach for those items that we fail to remove from the access container. My stats show there are 9 instances where this occurs. 

[base-stats.txt](https://github.com/pmem/CacheLib/files/9103439/base-stats.txt)
[single-stats.txt](https://github.com/pmem/CacheLib/files/9103440/single-stats.txt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/94)
<!-- Reviewable:end -->
