### PR TITLE
[Upstream] Create initial mmap PR based on Meta's guidelines (not ready for review yet)

### DIFF
--- a/cachelib/shm/PosixShmSegment.h
+++ b/cachelib/shm/PosixShmSegment.h
@@ -49,18 +49,13 @@ class PosixShmSegment : public ShmBase {
   //
   // @param name  Name of the segment
   // @param opts  the options for attaching to the segment.
-  PosixShmSegment(ShmAttachT,
-                  const std::string& name,
-                  ShmSegmentOpts opts = {});
+  PosixShmSegment(ShmAttachT, ShmSegmentOpts opts);
 
   // create a new segment
   // @param name  The name of the segment
   // @param size  The size of the segment. This will be rounded up to the
   //              nearest page size.
-  PosixShmSegment(ShmNewT,
-                  const std::string& name,
-                  size_t size,
-                  ShmSegmentOpts opts = {});
+  PosixShmSegment(ShmNewT, size_t size, ShmSegmentOpts opts);
 
   // destructor
   ~PosixShmSegment() override;
@@ -95,11 +90,11 @@ class PosixShmSegment : public ShmBase {
   static bool removeByName(const std::string& name);
 
  private:
-  static int createNewSegment(const std::string& name);
-  static int getExisting(const std::string& name, const ShmSegmentOpts& opts);
+  static int createNewSegment(const ShmSegmentOpts& opts);
+  static int getExisting(const ShmSegmentOpts& opts);
 
   // returns the key type corresponding to the given name.
-  static std::string createKeyForName(const std::string& name) noexcept;
+  static std::string createKeyForName(const ShmSegmentOpts& opts) noexcept;
 
   // resize the segment
   // @param size  the new size

--- a/cachelib/shm/Shm.h
+++ b/cachelib/shm/Shm.h
@@ -44,36 +44,23 @@ namespace cachelib {
 class ShmSegment {
  public:
   // create a new segment with the given key
-  // @param name   name of the segment
   // @param size   size of the segment.
   // @param opts   the options for the segment.
-  ShmSegment(ShmNewT,
-             std::string name,
-             size_t size,
-             bool usePosix,
-             ShmSegmentOpts opts = {}) {
-    if (usePosix) {
-      segment_ = std::make_unique<PosixShmSegment>(ShmNew, std::move(name),
-                                                   size, opts);
+  ShmSegment(ShmNewT, size_t size, ShmSegmentOpts opts) {
+    if (opts.typeOpts.type == ShmTypeT::POSIX) {
+      segment_ = std::make_unique<PosixShmSegment>(ShmNew, size, opts);
     } else {
-      segment_ =
-          std::make_unique<SysVShmSegment>(ShmNew, std::move(name), size, opts);
+      segment_ = std::make_unique<SysVShmSegment>(ShmNew, size, opts);
     }
   }
 
   // attach to an existing segment with the given key
-  // @param name   name of the segment
   // @param opts   the options for the segment.
-  ShmSegment(ShmAttachT,
-             std::string name,
-             bool usePosix,
-             ShmSegmentOpts opts = {}) {
-    if (usePosix) {
-      segment_ =
-          std::make_unique<PosixShmSegment>(ShmAttach, std::move(name), opts);
+  ShmSegment(ShmAttachT, ShmSegmentOpts opts) {
+    if (opts.typeOpts.type == ShmTypeT::POSIX) {
+      segment_ = std::make_unique<PosixShmSegment>(ShmAttach, opts);
     } else {
-      segment_ =
-          std::make_unique<SysVShmSegment>(ShmAttach, std::move(name), opts);
+      segment_ = std::make_unique<SysVShmSegment>(ShmAttach, opts);
     }
   }
 

--- a/cachelib/shm/ShmCommon.h
+++ b/cachelib/shm/ShmCommon.h
@@ -70,10 +70,22 @@ enum PageSizeT {
   ONE_GB,
 };
 
+enum ShmTypeT {
+  POSIX = 0,
+  SYS_V,
+  FILE,
+};
+
+struct ShmTypeOpts {
+  ShmTypeT type{ShmTypeT::POSIX};
+  std::string id{};
+};
+
 struct ShmSegmentOpts {
   PageSizeT pageSize{PageSizeT::NORMAL};
   bool readOnly{false};
-  size_t alignment{1}; // alignment for mapping.
+  size_t alignment{1};    // alignment for mapping.
+  ShmTypeOpts typeOpts{}; // opts specific to segment type
 
   explicit ShmSegmentOpts(PageSizeT p) : pageSize(p) {}
   explicit ShmSegmentOpts(PageSizeT p, bool ro) : pageSize(p), readOnly(ro) {}
@@ -94,8 +106,7 @@ struct ShmAddr {
 /* common interface for both posix and sysv shared memory segments */
 class ShmBase {
  public:
-  ShmBase(ShmSegmentOpts opts, std::string name)
-      : opts_(std::move(opts)), name_(std::move(name)) {}
+  ShmBase(ShmSegmentOpts opts) : opts_(std::move(opts)) {}
   ShmBase(const ShmBase&) = delete;
   ShmBase& operator=(const ShmBase&) = delete;
 
@@ -112,7 +123,7 @@ class ShmBase {
   virtual void unMap(void* addr) const = 0;
   virtual void markForRemoval() = 0;
 
-  const std::string& getName() const { return name_; }
+  const std::string& getName() const { return opts_.typeOpts.id; }
 
  protected:
   void markActive() noexcept { state_ = State::NORMAL; }
@@ -128,7 +139,6 @@ class ShmBase {
  private:
   enum class State { NORMAL, MARKED_FOR_REMOVAL };
   State state_{State::NORMAL}; // current state of the segment.
-  std::string name_{};         // name of the segment
 };
 
 namespace detail {

--- a/cachelib/shm/ShmManager.h
+++ b/cachelib/shm/ShmManager.h
@@ -226,6 +226,10 @@ class ShmManager {
   // file and used for attaching to the segment.
   std::unordered_map<std::string, std::string> nameToKey_{};
 
+  // name to ShmTypeOpts mapping used for reattaching. This is persisted to a
+  // file and used for attaching to the segment.
+  std::unordered_map<std::string, ShmTypeOpts> nameToType_{};
+
   // file handle for the metadata file. It remains open throughout the lifetime
   // of the object.
   std::ofstream metadataStream_;
@@ -234,6 +238,7 @@ class ShmManager {
   // throughout the lifetime of the object.
   folly::File metaDataLockFile_;
 
+  // Use posix is a NO-OP field retained for backward compatibility.
   const bool usePosix_{false};
 
   // this file is used to persist the name to key mapping so that we can

--- a/cachelib/shm/SysVShmSegment.h
+++ b/cachelib/shm/SysVShmSegment.h
@@ -42,18 +42,14 @@ class SysVShmSegment : public ShmBase {
   //
   // @param key   the key for the segment.
   // @param opts  the options for attaching the segment.
-  SysVShmSegment(ShmAttachT, const std::string& name, ShmSegmentOpts opts = {});
+  SysVShmSegment(ShmAttachT, ShmSegmentOpts opts);
 
   // creates a news segment with the given key.
   //
-  // @param key   the key for the segment.
   // @param size  the size of the segment. This will be rounded up to the
   //              nearest page size
   // @param opts  the options for creating the segment.
-  SysVShmSegment(ShmNewT,
-                 const std::string& name,
-                 size_t size,
-                 ShmSegmentOpts opts = {});
+  SysVShmSegment(ShmNewT, size_t size, ShmSegmentOpts opts);
 
   ~SysVShmSegment() override try {
     // delete the reference mapping so the segment can be deleted if its
@@ -86,16 +82,14 @@ class SysVShmSegment : public ShmBase {
 
   // useful for removing without attaching
   // @return true if the segment existed. false otherwise
-  static bool removeByName(const std::string& name);
+  static bool removeByName(const ShmSegmentOpts& opts);
 
  private:
   // returns the key identifier for the given name.
-  static KeyType createKeyForName(const std::string& name) noexcept;
+  static KeyType createKeyForName(const ShmSegmentOpts& opts) noexcept;
 
-  static int createNewSegment(key_t key,
-                              size_t size,
-                              const ShmSegmentOpts& opts);
-  static int attachToExisting(key_t key, const ShmSegmentOpts& opts);
+  static int createNewSegment(size_t size, const ShmSegmentOpts& opts);
+  static int attachToExisting(const ShmSegmentOpts& opts);
   void lockPagesInMemory() const;
   void createReferenceMapping();
   void deleteReferenceMapping() const;


### PR DESCRIPTION
Instruction from Meta for first PR:

1. Create a class containing Id and Type of a segment called ShmTypeOpts. The type is an enum. The ID is a string. Put ShmTypeOpts into ShmSegmentOpts.
2. ShmBase is initialized solely with ShmSegmentOpts since name_ can now be initialized with the ID in ShmSegmentOpts.ShmTypeOpts.
3. Posix/SysVShmSegment class (subclasses of ShmBase) will be new-ed/attached without an extra name input.
4. ShmSegment class (the class that wraps a ShmBase) will be new-ed/attached without name or usePosix because that can be retrieved with ShmSegmentOpts.ShmTypeOpts).
5. In ShmManager, we keep a map from name to ShmTypeOpts called nameToType_ (replacing nameToKey_, but we will need to keep nameToKey_ for compatibility reason).
6. When creating a new segment via ShmManager, we expect a name and ShmTypeOpts to be provided. If the type indicates SysV or Posix, we ignore the id field in ShmTypeOpts and fill the id field with uniqueIdForName. We use this ShmTypeOpts to create the segment then save the segment into segments_ and save the ShmTypeOpts to nameToType_.
7. When attaching/removing a segment via ShmManager, we expect only the name provided. ShmManager looks up the segment and the ShmTypeOpts from nameToType_ and try to attach/remove with the ShmTypeOpts retrieved.
8. When removing a segment via the static function of ShmManager, we expect ShmTypeOpts to be provided directly.
9. After the first diff, the usePosix_ field inside ShmManager will be noop since each segment know what type they are from nameToType_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/cachelib/99)
<!-- Reviewable:end -->
